### PR TITLE
Update dependent code and examples to use snake_case names (Phase 5)

### DIFF
--- a/examples/get_latest_argus.py
+++ b/examples/get_latest_argus.py
@@ -7,7 +7,7 @@ and saves it as a GeoTIFF. Supports multiple image types: 'bright', 'timex', 'sn
 import argparse
 import datetime as DT
 import os
-from murgtools.getdata import findArgusImagery
+from murgtools.getdata import find_argus_imagery
 
 
 def main():
@@ -30,7 +30,7 @@ def main():
 
     # Use method=1 (backward search) to find the most recent available image
     # search_window_hours=48 gives a 2-day window to find imagery
-    result = findArgusImagery(
+    result = find_argus_imagery(
         dateOfInterest=utc_time,
         filename=output_file,
         imageType= image_type,

--- a/examples/test_wave_and_imagery.py
+++ b/examples/test_wave_and_imagery.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 import numpy as np
 
-from murgtools.getdata import getObs, getSatelliteImagery, findArgusImagery, get_geotiff_extent
+from murgtools.getdata import getObs, getSatelliteImagery, find_argus_imagery, get_geotiff_extent
 from murgtools.utils import geoprocess as gp
 
 
@@ -55,7 +55,7 @@ def main():
     for gauge in gauge_list:
         print(f"  Fetching {gauge}...")
         try:
-            data = obs.getWaveData(gaugenumber=gauge, roundto=30)
+            data = obs.get_wave_data(gaugenumber=gauge, roundto=30)
             if data is not None and 'Hs' in data:
                 wave_data[gauge] = data
                 # Get lat/lon from xFRF/yFRF using geoprocess
@@ -116,10 +116,10 @@ def main():
         tmp_path = tmp.name
 
     try:
-        # Use findArgusImagery with method=1 (nearest in history) to get most recent image
+        # Use find_argus_imagery with method=1 (nearest in history) to get most recent image
         # Using 'bright' (brightest pixels composite) for best visualization
-        argus_result = findArgusImagery(now, filename=tmp_path, imageType='bright',
-                                        search_window_hours=48, method=1)
+        argus_result = find_argus_imagery(now, filename=tmp_path, imageType='bright',
+                                          search_window_hours=48, method=1)
         if argus_result:
             print(f"  Got Argus image from {argus_result['time'].strftime('%Y-%m-%d %H:%M')}")
             print(f"  Shape: {argus_result['image'].shape}")

--- a/murgtools/getdata/getDataFRF.py
+++ b/murgtools/getdata/getDataFRF.py
@@ -903,7 +903,7 @@ class getObs:
         return self._get_with_cache('currents', fetch_data, cache_params, force_refresh)
 
     def _getCurrents_impl(self, gaugenumber, roundto):
-        """Internal implementation of getCurrents (without caching)."""
+        """Internal implementation of get_currents (without caching)."""
         valid_gauges = [2, 3, 4, 5, 6, 'awac-11m', 'awac-8m', 'awac-6m', 'awac-4.5m', 'awac-5m',
                         'adop-3.5m', 'awac-jpier-11m', 'awac-jpier', 'jpier-11m',
                         'sig769-300', '769-300',
@@ -1050,7 +1050,7 @@ class getObs:
         return self._get_with_cache('wind', fetch_data, cache_params, force_refresh)
 
     def _getWind_impl(self, gaugenumber, collectionlength):
-        """Internal implementation of getWind (without caching)."""
+        """Internal implementation of get_wind (without caching)."""
         # Making gauges flexible
         # different Gauges
         if gaugenumber in ['derived', 'Derived', 0]:
@@ -1180,7 +1180,7 @@ class getObs:
         return self._get_with_cache('waterlevel', fetch_data, cache_params, force_refresh)
 
     def _getWL_impl(self, collectionlength):
-        """Internal implementation of getWL (without caching)."""
+        """Internal implementation of get_wl (without caching)."""
         # this is the back end of the url for waterlevel
         self.dataloc = 'oceanography/waterlevel/eopNoaaTide/eopNoaaTide.ncml'
 
@@ -2176,7 +2176,7 @@ class getObs:
         return self._get_with_cache('altimeter', fetch_data, cache_params, force_refresh)
 
     def _getALT_impl(self, gaugeName, removeMasked):
-        """Internal implementation of getALT (without caching)."""
+        """Internal implementation of get_alt (without caching)."""
         # location of the data
         gauge_list = ['Alt769-150', 'Alt769-200', 'Alt769-250', 'Alt769-300', 'Alt769-350',
                       'Alt861-150', 'Alt861-200', 'Alt861-250', 'Alt861-300', 'Alt861-350',
@@ -4112,7 +4112,7 @@ def getArgusPixelIntensity(times, location, coordType='FRF', imageType='timex',
                            channel=None, verbose=True, **kwargs):
     """Extract pixel intensity values from Argus imagery at a specified location.
 
-    This function wraps getArgusImagery to extract pixel intensities over multiple
+    This function wraps get_argus_imagery to extract pixel intensities over multiple
     times and image types. It handles coordinate transformations and returns timestamps
     with pixel values to account for gaps in imagery.
 
@@ -4144,7 +4144,7 @@ def getArgusPixelIntensity(times, location, coordType='FRF', imageType='timex',
             - 'gray' or 'grey' or 'bw': Grayscale (weighted average using standard luminance formula)
             - None: Return all RGB channels (default)
         verbose (bool, optional): Enable logging output. Defaults to True.
-        **kwargs: Additional arguments passed to findArgusImagery (e.g.,
+        **kwargs: Additional arguments passed to find_argus_imagery (e.g.,
             search_window_hours, method)
 
     Returns:

--- a/murgtools/getdata/getPlotData.py
+++ b/murgtools/getdata/getPlotData.py
@@ -39,7 +39,7 @@ def alt_PlotData(name, mod_time, mod_times, THREDDS='FRF'):
 
     try:
         dict = {}
-        alt_data = frf_Data.getALT(name)
+        alt_data = frf_Data.get_alt(name)
         dict['zb'] = alt_data['bottomElev']
         dict['time'] = alt_data['time']
         dict['name'] = alt_data['gageName']
@@ -186,7 +186,7 @@ def CMSF_velData(cmsfDict, station, dThresh=None):
                     'time' - this needs to be in epochtime
                     'aveE' - average eastward velocity
                     'aveN' - average northward velocity
-        station: this is the stationname that will get handed to getCurrents, a gagenumber would (should?) also work
+        station: this is the stationname that will get handed to get_currents, a gagenumber would (should?) also work
 
     Returns:
          dictionary with keys:


### PR DESCRIPTION
## Summary
Updates all internal code, examples, and docstrings to use the new snake_case method names introduced in Phase 3+4.

## Changes

### Internal Code
- `murgtools/getdata/getPlotData.py`: `getALT` → `get_alt`, docstring updated

### Examples
- `examples/get_latest_argus.py`: `findArgusImagery` → `find_argus_imagery`
- `examples/test_wave_and_imagery.py`: 
  - `getWaveData` → `get_wave_data`
  - `findArgusImagery` → `find_argus_imagery`

### Docstrings
- Internal implementation method docstrings updated to reference snake_case names
- `getArgusPixelIntensity` docstring updated

## Test plan
- [x] All 239 tests pass
- [x] No remaining old method names in internal code or examples
- [x] Deprecated aliases still available in `__init__.py` for backward compatibility

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)